### PR TITLE
Return parsed json

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules

--- a/README.md
+++ b/README.md
@@ -143,6 +143,7 @@ The zone parameter is optional, you can pass a number or a string
 
 #### Promises
 All these methods return a promise:
+The resolved promise result will have been parsed from JSON into an object if the response `content-type` was `application/json`.
 ```javascript
 yamaha.powerOff().then(function(result){
 	console.log("Response is" + result);

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,69 @@
+{
+  "name": "yamaha-yxc-nodejs",
+  "version": "0.0.12",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "@root/request": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@root/request/-/request-1.5.0.tgz",
+      "integrity": "sha512-J9RUIwVU99/cOVuDVYlNpr4G0A1/3ZxhCXIRiTZzu8RntOnb0lmDBMckhaus5ry9x/dBqJKDplFIgwHbLi6rLA=="
+    },
+    "assertion-error": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.1.0.tgz",
+      "integrity": "sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw==",
+      "dev": true
+    },
+    "bluebird": {
+      "version": "3.7.2",
+      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.7.2.tgz",
+      "integrity": "sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg=="
+    },
+    "chai": {
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-3.5.0.tgz",
+      "integrity": "sha1-TQJjewZ/6Vi9v906QOxW/vc3Mkc=",
+      "dev": true,
+      "requires": {
+        "assertion-error": "^1.0.1",
+        "deep-eql": "^0.1.3",
+        "type-detect": "^1.0.0"
+      }
+    },
+    "chai-as-promised": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/chai-as-promised/-/chai-as-promised-5.3.0.tgz",
+      "integrity": "sha1-CdekApCKpw39vq1T5YU/x50+8hw=",
+      "dev": true
+    },
+    "deep-eql": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-0.1.3.tgz",
+      "integrity": "sha1-71WKyrjeJSBs1xOQbXTlaTDrafI=",
+      "dev": true,
+      "requires": {
+        "type-detect": "0.1.1"
+      },
+      "dependencies": {
+        "type-detect": {
+          "version": "0.1.1",
+          "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-0.1.1.tgz",
+          "integrity": "sha1-C6XsKohWQORw6k6FBZcZANrFiCI=",
+          "dev": true
+        }
+      }
+    },
+    "peer-ssdp": {
+      "version": "0.0.5",
+      "resolved": "https://registry.npmjs.org/peer-ssdp/-/peer-ssdp-0.0.5.tgz",
+      "integrity": "sha1-G5FVuolGXszE3iy6LAOOSf3iooE="
+    },
+    "type-detect": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-1.0.0.tgz",
+      "integrity": "sha1-diIXzAbbJY7EiQihKY6LlRIejqI=",
+      "dev": true
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "yamaha-yxc-nodejs",
-  "version": "0.0.12",
+  "version": "1.0.0",
   "description": "NodeJS API to control your YAMAHA Musiccast devices",
   "main": "yamahayxc.js",
   "dependencies": {


### PR DESCRIPTION
 - create a generic request method (that can make  'GET', 'POST', 'PUT'.... etc)
 - new method uses async/await instead of promises directly (because i think it is neater)
 - ensure that the new method parses the response body if it is of type JSON.
 - thin out GET and POST methods and point them at the new generic request method instead.
 - major version bump because parsing the response object is technically a breaking change

-----

CHANGELOG not updated